### PR TITLE
fix(workflows): add OPENAI_BASE_URL to workflow

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -26,6 +26,7 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
           WHITELIST: ${{ secrets.WHITELIST }}
           CONFIG: ${{ vars.CONFIG }}
           ACTOR: ${{ github.actor }}

--- a/prompts/common.ts
+++ b/prompts/common.ts
@@ -17,7 +17,13 @@ import { checkValid, checkWhitelist } from "./quota.ts";
 const apiKey = Deno.env.get("OPENAI_API_KEY");
 assert(apiKey, "failed to get openAI API key");
 
+// default: https://api.openai.com/v1
+// my: https://api.ezchat.top/v1
+const baseURL = Deno.env.get("OPENAI_BASE_URL");
+assert(baseURL, "failed to get OPENAI_BASE_URL");
+
 const openai = new OpenAI({
+  baseURL: baseURL,
   apiKey: apiKey,
 });
 


### PR DESCRIPTION
Add OPENAI_BASE_URL as a secret in the GitHub workflow to configure base URL for OpenAI API, enhancing flexibility and security.