### PR TITLE
Setup release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: '1.x'
+
+      - name: Read jsr.json
+        id: read-jsr-json
+        run: |
+          VERSION=$(deno eval 'import { readFileSync } from "node:fs"; const json = JSON.parse(readFileSync("jsr.json", { encoding: "utf8" })); console.log(json.version)')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Verify tag
+        if: github.ref_name != steps.read-jsr-json.outputs.version
+        run: |
+          echo "Tag ${github.ref_name} does not match jsr.json version ${{ steps.read-jsr-json.outputs.version }}"
+          exit 1
+
+      - name: Publish to JSR
+        run: deno publish
+        env:
+          DENO_AUTH_TOKENS: ${{ secrets.JSR_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically release to JSR when a semantic versioned tag is created.